### PR TITLE
Fix GitHub Actions permissions

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -5,6 +5,12 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+# Explicitly define permissions for GITHUB_TOKEN
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds explicit permissions to the GitHub Actions workflow to allow it to push to the gh-pages branch. This fixes the deployment error: 'Permission to DeDuckProject/epp-demo.git denied to github-actions[bot]'.