### PR TITLE
Fix typo in info window

### DIFF
--- a/src/components/InfoWindow.tsx
+++ b/src/components/InfoWindow.tsx
@@ -187,7 +187,7 @@ const InfoWindow: React.FC<InfoWindowProps> = ({ isOpen, onClose }) => {
             <p>
               We acknowledge and credit <a href="https://github.com/a-auer/qiskit" target="_blank" rel="noopener noreferrer">
               https://github.com/a-auer/qiskit</a> for explaining and implementing the protocol, 
-              which served as a reference for our implementation. It also contains a much deeper explanation then this application provides.
+              which served as a reference for our implementation. It also contains a much deeper explanation than this application provides.
             </p>
             <p>
               The application was built as a project at the Hebrew University of Jerusalem


### PR DESCRIPTION
## Summary
- correct a typo in InfoWindow text

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5ee031f8832e8c8307b855bdb9e7