### PR TITLE
Remove console output from tests

### DIFF
--- a/tests/engine-real-calculations/bell/bell-basis.test.ts
+++ b/tests/engine-real-calculations/bell/bell-basis.test.ts
@@ -257,7 +257,6 @@ describe('Testing non-Bell-diagonal matrices', () => {
     
     // Current implementation: should return 0.4 (diagonal element)
     const fidelity = fidelityFromBellBasisMatrix(coherentMatrix, BellState.PHI_PLUS);
-    console.log('Coherent matrix fidelity (current implementation):', fidelity);
     
     // For comparison: if this were a diagonal matrix with same diagonal elements
     const diagonalData = [
@@ -268,7 +267,6 @@ describe('Testing non-Bell-diagonal matrices', () => {
     ];
     const diagonalMatrix = new Matrix(diagonalData);
     const diagonalFidelity = fidelityFromBellBasisMatrix(diagonalMatrix, BellState.PHI_PLUS);
-    console.log('Diagonal matrix fidelity:', diagonalFidelity);
     
     // They should be the same for quantum fidelity F(ρ,|ψ⟩⟨ψ|) = ⟨ψ|ρ|ψ⟩
     expect(fidelity).toBeCloseTo(0.4, 5);
@@ -287,7 +285,6 @@ describe('Testing non-Bell-diagonal matrices', () => {
     const complexMatrix = new Matrix(complexData);
     
     const fidelity = fidelityFromBellBasisMatrix(complexMatrix, BellState.PHI_PLUS);
-    console.log('Complex matrix fidelity:', fidelity);
     
     // Should still be 0.5 (the diagonal element) for F(ρ,|ψ⟩⟨ψ|) = ⟨ψ|ρ|ψ⟩
     expect(fidelity).toBeCloseTo(0.5, 5);
@@ -319,9 +316,6 @@ describe('Testing non-Bell-diagonal matrices', () => {
     const wernerBell = toBellBasis(wernerComp);
     const fidelityFromBell = fidelityFromBellBasisMatrix(wernerBell, BellState.PHI_PLUS);
     
-    console.log('Werner state fidelity from computational basis:', fidelityFromComp);
-    console.log('Werner state fidelity from Bell basis:', fidelityFromBell);
-    console.log('Werner state Bell basis matrix diagonal:', wernerBell.get(0,0).re);
     
     // Both should give the same result
     expect(fidelityFromComp).toBeCloseTo(fidelityFromBell, 10);

--- a/tests/engine/operations.test.ts
+++ b/tests/engine/operations.test.ts
@@ -120,7 +120,10 @@ describe('operations', () => {
       // Let's just check if the fidelity calculation runs.
       const controlPair = createNoisyEPRWithChannel(0.1, NoiseChannel.UniformNoise);
       const targetPair = createNoisyEPRWithChannel(0.1, NoiseChannel.UniformNoise);
+      const originalRandom = Math.random;
+      Math.random = () => 0; // force success
       const result = bilateralCNOT(controlPair, targetPair);
+      Math.random = originalRandom;
 
       // Original test used calculateBellBasisFidelity(transformToBellBasis(rho))
       // New approach: Use helper function calculateFidelityWrtPhiPlus
@@ -128,7 +131,8 @@ describe('operations', () => {
       const finalFidelity = fidelityFromBellBasisMatrix(result.afterMeasurement.controlPair); // Helper uses get()
       
       expect(finalFidelity).toBeDefined();
-      console.log(`Bilateral CNOT: Initial Fidelity=${initialFidelity}, Final Fidelity=${finalFidelity}, Success=${result.afterMeasurement.successful}`);
+      expect(result.afterMeasurement.successful).toBe(true);
+      expect(finalFidelity).toBeGreaterThanOrEqual(initialFidelity);
       // TODO: Add more rigorous tests, potentially with known input/output states if the operation simplifies
       // or via statistical analysis if the exact BCNOT+measurement implementation is confirmed.
     });


### PR DESCRIPTION
## Summary
- drop `console.log` statements from bell basis tests
- make bilateralCNOT test deterministic and check that fidelity improves

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5eeb36b8832eade5b244f51a563b