### PR TITLE
Show help panel automatically on first load

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -16,6 +16,13 @@ const App: React.FC = () => {
   const [viewBasis, setViewBasis] = useState<Basis>(Basis.Bell);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [infoOpen, setInfoOpen] = useState(false);
+
+  // Show the educational panel automatically on first run
+  useEffect(() => {
+    if (!localStorage.getItem('infoWindowSeen')) {
+      setInfoOpen(true);
+    }
+  }, []);
   
   useEffect(() => {
     // Initialize controller with default parameters
@@ -44,6 +51,11 @@ const App: React.FC = () => {
     setEngineType(type);
   };
   
+  const handleInfoClose = () => {
+    setInfoOpen(false);
+    localStorage.setItem('infoWindowSeen', 'true');
+  };
+
   return (
     <div className="app-container">
       <header>
@@ -101,9 +113,9 @@ const App: React.FC = () => {
         </div>
       </main>
       
-      <InfoWindow 
+      <InfoWindow
         isOpen={infoOpen}
-        onClose={() => setInfoOpen(false)}
+        onClose={handleInfoClose}
       />
       
       <Attribution />

--- a/tests/components/App.test.tsx
+++ b/tests/components/App.test.tsx
@@ -61,6 +61,8 @@ describe('App', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
+    localStorage.setItem('infoWindowSeen', 'true');
     
     // Setup the controller mock to provide immediate state
     (SimulationController as unknown as ReturnType<typeof vi.fn>).mockImplementation(
@@ -328,4 +330,22 @@ describe('App', () => {
     // Verify the header contains the title
     expect(header).toContainElement(headerTitle);
   });
-}); 
+
+  test('shows info window on first run when not previously seen', () => {
+    localStorage.clear();
+
+    render(<App />);
+
+    expect(screen.getByTestId('info-window')).toBeInTheDocument();
+  });
+
+  test('closing info window sets localStorage flag', () => {
+    localStorage.clear();
+
+    render(<App />);
+
+    fireEvent.click(screen.getByLabelText('Close information window'));
+
+    expect(localStorage.getItem('infoWindowSeen')).toBe('true');
+  });
+});


### PR DESCRIPTION
## Summary
- revert changes that showed help popup in `ControlPanel`
- show `InfoWindow` automatically on first run
- save dismissal state in `localStorage`
- update `App` tests for new functionality

## Testing
- `npm test` *(fails: vitest not found)*


------
https://chatgpt.com/codex/tasks/task_e_683f6078a700832e9d1ed9ee24638005