### PR TITLE
Add GitGlimpse workflow for automated demo recording

### DIFF
--- a/.github/workflows/git-glimpse-ack.yml
+++ b/.github/workflows/git-glimpse-ack.yml
@@ -1,0 +1,21 @@
+name: GitGlimpse Acknowledge
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  ack:
+    if: >-
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '/glimpse')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: React with eyes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/$GITHUB_REPOSITORY/issues/comments/${{ github.event.comment.id }}/reactions \
+            --method POST --field content=eyes || true

--- a/.github/workflows/git-glimpse.yml
+++ b/.github/workflows/git-glimpse.yml
@@ -1,0 +1,59 @@
+name: GitGlimpse
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  issue_comment:
+    types: [created]
+
+jobs:
+  demo:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '/glimpse'))
+    permissions:
+      pull-requests: write
+      contents: write
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - run: npm ci
+
+      - name: Install FFmpeg
+        run: sudo apt-get install -y ffmpeg
+
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium --with-deps
+
+      - uses: DeDuckProject/git-glimpse@v1
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: React with hooray on success
+        if: github.event_name == 'issue_comment' && success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/$GITHUB_REPOSITORY/issues/comments/${{ github.event.comment.id }}/reactions \
+            --method POST --field content=hooray || true
+
+      - name: React with confused on failure
+        if: github.event_name == 'issue_comment' && failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/$GITHUB_REPOSITORY/issues/comments/${{ github.event.comment.id }}/reactions \
+            --method POST --field content=confused || true

--- a/git-glimpse.config.ts
+++ b/git-glimpse.config.ts
@@ -5,9 +5,6 @@ export default {
     startCommand: 'npm run dev',
     readyWhen: { url: 'http://localhost:5173/epp-demo/' },
   },
-  trigger: {
-    mode: 'auto',
-  },
   recording: {
     format: 'gif',
     maxDuration: 30,

--- a/git-glimpse.config.ts
+++ b/git-glimpse.config.ts
@@ -5,6 +5,9 @@ export default {
     startCommand: 'npm run dev',
     readyWhen: { url: 'http://localhost:5173/epp-demo/' },
   },
+  trigger: {
+    mode: 'auto',
+  },
   recording: {
     format: 'gif',
     maxDuration: 30,

--- a/git-glimpse.config.ts
+++ b/git-glimpse.config.ts
@@ -1,0 +1,13 @@
+import type { GitGlimpseConfig } from '@git-glimpse/core';
+
+export default {
+  app: {
+    startCommand: 'npm run dev',
+    readyWhen: { url: 'http://localhost:5173/epp-demo/' },
+  },
+  recording: {
+    format: 'gif',
+    maxDuration: 30,
+    viewport: { width: 1280, height: 720 },
+  },
+} satisfies GitGlimpseConfig;


### PR DESCRIPTION
## Summary
This PR adds automated demo recording capabilities to the repository using GitGlimpse, a tool that generates visual recordings of application interactions. The implementation includes GitHub Actions workflows and configuration to automatically record demos on pull requests and via comment commands.

## Key Changes
- **GitHub Actions Workflows**:
  - `git-glimpse.yml`: Main workflow that triggers on pull requests and `/glimpse` comments, sets up the environment (Node.js, FFmpeg, Playwright), and runs the GitGlimpse action with appropriate permissions and error handling
  - `git-glimpse-ack.yml`: Acknowledgment workflow that reacts with an "eyes" emoji when a `/glimpse` command is detected on a PR comment

- **GitGlimpse Configuration** (`git-glimpse.config.ts`):
  - Configured to start the development server via `npm run dev`
  - Set to wait for application readiness at `http://localhost:5173/epp-demo/`
  - Recording settings: GIF format, 30-second max duration, 1280x720 viewport

## Implementation Details
- The main workflow runs on PR open/sync events and on `/glimpse` comments on PRs
- Requires `ANTHROPIC_API_KEY` and `GITHUB_TOKEN` secrets for operation
- Includes success/failure reactions on comment-triggered runs for user feedback
- Proper checkout configuration handles both PR and comment-triggered scenarios with appropriate ref resolution

https://claude.ai/code/session_01L74tc3msNfg2KcEuUef4Wf